### PR TITLE
Bump ms-azuretools.vscode-docker to ms-azuretools.vscode-container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,7 @@
 					"editor.quickSuggestions": {
 						"strings": true
 					},
-					"editor.defaultFormatter": "ms-azuretools.vscode-docker"
+					"editor.defaultFormatter": "ms-azuretools.vscode-containers"
 				},
 				"python.analysis.typeCheckingMode": "strict",
 				"python.analysis.autoImportCompletions": true
@@ -84,7 +84,7 @@
 				"ms-python.black-formatter",
 				"usernamehw.errorlens",
 				"redhat.vscode-yaml",
-				"ms-azuretools.vscode-docker"
+				"ms-azuretools.vscode-containers"
 			]
 		}
 	}


### PR DESCRIPTION
- see https://github.com/microsoft/vscode-docker/releases/tag/v2.0.0
- fixes "Value is not accepted." error