### PR TITLE
Update devcontainer extensions and configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,7 +70,14 @@
 					"editor.defaultFormatter": "ms-azuretools.vscode-containers"
 				},
 				"python.analysis.typeCheckingMode": "strict",
-				"python.analysis.autoImportCompletions": true
+				"python.analysis.autoImportCompletions": true,
+				// disable schema validation for otel collector config files, as there's no schema available on SchemaStore yet
+				"yaml.schemas": {
+					"":[
+						"**/otel-collector-config*.yaml",
+						"**/collector/**/*.yaml"
+					]
+				}
 			},
 			"extensions": [
 				"vscjava.vscode-java-pack",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,7 @@
 					"editor.quickSuggestions": {
 						"strings": true
 					},
-					"editor.defaultFormatter": "ms-azuretools.vscode-docker"
+					"editor.defaultFormatter": "ms-azuretools.vscode-containers"
 				},
 				"python.analysis.typeCheckingMode": "strict",
 				"python.analysis.autoImportCompletions": true
@@ -84,7 +84,7 @@
 				"ms-python.black-formatter",
 				"usernamehw.errorlens",
 				"redhat.vscode-yaml",
-				"ms-azuretools.vscode-docker"
+				"ms-azuretools.vscode-containers"
 			]
 		}
 	}


### PR DESCRIPTION
- disabling schema validation for the otel collector, as the RHEL yaml extension currently throws an error since it finds the schema for the [OTel declarative configuration](https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json) on SchemaStore.
- updating the ms-azuretools.vscode-docker extension to ms-azuretools.vscode.container, as described in https://github.com/microsoft/vscode-docker/releases/tag/v2.0.0